### PR TITLE
strip the class name in type_info from srefl

### DIFF
--- a/mirrow/mirrow/srefl/srefl_begin.hpp
+++ b/mirrow/mirrow/srefl/srefl_begin.hpp
@@ -11,7 +11,7 @@
     template <>                                     \
     struct type_info<type> : base_type_info<type> { \
         static constexpr std::string_view name() {  \
-            return #type;                           \
+            return strip_name(#type);               \
         }                                           \
         __VA_ARGS__                                 \
     };


### PR DESCRIPTION
**Case 1:**
We write reflection information outside the namespace as follows:
```cpp
// In main.hh
#pragma once
namespace myns{
struct Pos
{
    int x, y;
};
}  // namespace myns

#include "mirrow/srefl/srefl_begin.hpp"
srefl_class(myns::Pos,
    fields(
        field(&myns::Pos::x),
        field(&myns::Pos::y)
    )
)
#include "mirrow/srefl/srefl_end.hpp"

// In main.cc
#include <iostream>
#include <main.hh>
int main()
{
    // we need to specify "myns::Pos"
    auto refl = mirrow::srefl::reflect<myns::Pos>();
    // the expected behavior is to print "Pos", but "myns::Pos" now
    std::cout << refl.name() << std::endl; 
    return 0;
}
```
**Case 2:**
We write reflection information inside the namespace as follows:
```cpp
// In main.hh
#pragma once
namespace myns{
struct Pos
{
    int x, y;
};
#include "mirrow/srefl/srefl_begin.hpp"
srefl_class(Pos,
    fields(
        field(&Pos::x),
        field(&Pos::y)
    )
)
#include "mirrow/srefl/srefl_end.hpp"
}  // namespace myns

// In main.cc
#include <iostream>
#include <main.hh>
int main()
{
    // it is noted that "mirrow" is now a sub-namespace of "myns", and we also need to specify "myns::Pos"
    auto refl = myns::mirrow::srefl::reflect<myns::Pos>();
    // finally, it can only print "Pos" now
    std::cout << refl.name() << std::endl; 
    return 0;
}
```

**Compiler:**
g++.exe (x86_64-win32-seh-rev2, Built by MinGW-Builds project) 14.2.0

**Changes:**
return strip_name(#type) when call `type_info<type>::name()`